### PR TITLE
Remove flag to request large exponent when creating keys (BIND always cr...

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+zkt 1.x
+
+* misc	Remove flag to request large exponent when creating keys
+	(BIND always creates keys with large exponents since BIND 9.5.0)
+
 zkt 1.1.2 -- 05. Dec 2012
 
 * bug	Fixed bug introduced by changes on inc_soa_serial()

--- a/dki.c
+++ b/dki.c
@@ -245,7 +245,6 @@ dki_t	*dki_new (const char *dir, const char *name, int ksk, int algo, int bitsiz
 	FILE	*fp;
 	int	len;
 	char	*flag = "";
-	char	*expflag = "";
 	dki_t	*new;
 
 	if ( ksk )
@@ -254,16 +253,13 @@ dki_t	*dki_new (const char *dir, const char *name, int ksk, int algo, int bitsiz
 	randfile[0] = '\0';
 	if ( rfile && *rfile )
 		snprintf (randfile, sizeof (randfile), "-r %.250s ", rfile);
-		
-	if ( algo == DK_ALGO_RSA || algo == DK_ALGO_RSASHA1 || algo == DK_ALGO_RSASHA256 || algo == DK_ALGO_RSASHA512 )
-		expflag = "-e ";
 
 	if ( dir && *dir )
-		snprintf (cmdline, sizeof (cmdline), "cd %s ; %s %s%s%s-n ZONE -a %s -b %d %s %s",
-			dir, KEYGENCMD, KEYGEN_COMPMODE, randfile, expflag, dki_algo2str(algo), bitsize, flag, name);
+		snprintf (cmdline, sizeof (cmdline), "cd %s ; %s %s%s-n ZONE -a %s -b %d %s %s",
+			dir, KEYGENCMD, KEYGEN_COMPMODE, randfile, dki_algo2str(algo), bitsize, flag, name);
 	else
-		snprintf (cmdline, sizeof (cmdline), "%s %s%s%s-n ZONE -a %s -b %d %s %s",
-			KEYGENCMD, KEYGEN_COMPMODE, randfile, expflag, dki_algo2str(algo), bitsize, flag, name);
+		snprintf (cmdline, sizeof (cmdline), "%s %s%s-n ZONE -a %s -b %d %s %s",
+			KEYGENCMD, KEYGEN_COMPMODE, randfile, dki_algo2str(algo), bitsize, flag, name);
 
 	dbg_msg (cmdline);
 


### PR DESCRIPTION
Remove flag to request large exponent when creating keys (BIND always creates keys with large exponents since BIND 9.5.0).
