### PR TITLE
Show name of zone if ksk key gets too old

### DIFF
--- a/rollover.c
+++ b/rollover.c
@@ -343,8 +343,8 @@ static	int	kskrollover (dki_t *ksk, zone_t *zonelist, zone_t *zp)
 		}
 		else	/* print out a warning only */
 		{
-			logmesg ("\t\tWarning: Lifetime of Key Signing Key %d exceeded: %s\n",
-							ksk->tag, str_delspace (age2str (age)));
+			logmesg ("\t\tWarning: %s: Lifetime of Key Signing Key %d exceeded: %s\n",
+							zp->zone, ksk->tag, str_delspace (age2str (age)));
 			lg_mesg (LG_WARNING, "\"%s\": lifetime of key signing key %d exceeded since %s",
 							zp->zone, ksk->tag, str_delspace (age2str (age - lifetime)));
 		}


### PR DESCRIPTION
This is handy because the warning is printed to the console and shown e.g. in cron mails. W/o this, you have to manually search for the specific zone based on the key id.